### PR TITLE
Add DTOs for stats endpoints

### DIFF
--- a/backend/local_app/kiva/models.py
+++ b/backend/local_app/kiva/models.py
@@ -84,3 +84,34 @@ class Loan(models.Model):
 
     class Meta:
         db_table = 'loan'
+
+
+class LoanStatsAvgLoanByCountry(models.Model):
+    country_name = models.TextField()
+    average_loan = models.FloatField()
+
+    class Meta:
+        db_table = 'loan'
+        managed = False
+
+
+class LoanStatsCommonSectorsAndActivities(models.Model):
+    sector_name = models.TextField()
+    activity_name = models.TextField()
+    average_lender_term_in_months = models.IntegerField()
+    count_of_loans = models.IntegerField()
+    average_loan = models.FloatField()
+
+    class Meta:
+        db_table = 'loan'
+        managed = False
+
+
+class LoanStatsAvgLendersGroupedBySectorAndActivity(models.Model):
+    average_lenders_per_loan = models.FloatField()
+    sector_name = models.TextField()
+    activity_name = models.TextField()
+
+    class Meta:
+        db_table = 'loan'
+        managed = False

--- a/backend/local_app/kiva/serializers.py
+++ b/backend/local_app/kiva/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
-from .models import Lender, Loan
+from .models import Lender, Loan, LoanStatsAvgLoanByCountry, LoanStatsCommonSectorsAndActivities,\
+    LoanStatsAvgLendersGroupedBySectorAndActivity
+
 
 class LenderSerializer(serializers.ModelSerializer):
     class Meta:
@@ -19,6 +21,7 @@ class LenderSerializer(serializers.ModelSerializer):
             'invited_by',
             'num_invited',
         )
+
 
 class LoanSerializer(serializers.ModelSerializer):
     class Meta:
@@ -50,4 +53,35 @@ class LoanSerializer(serializers.ModelSerializer):
             'borrower_genders',
             'repayment_interval',
             'distribution_model'
+        )
+
+
+class LoanStatsAvgLoanByCountrySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LoanStatsAvgLoanByCountry
+        fields = (
+            'country_name',
+            'average_loan'
+        )
+
+
+class LoanStatsCommonSectorsAndActivitiesSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LoanStatsCommonSectorsAndActivities
+        fields = (
+            'sector_name',
+            'activity_name',
+            'average_lender_term_in_months',
+            'count_of_loans',
+            'average_loan'
+        )
+
+
+class LoanStatsAvgLendersGroupedBySectorAndActivitySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LoanStatsAvgLendersGroupedBySectorAndActivity
+        fields = (
+            'average_lenders_per_loan',
+            'sector_name',
+            'activity_name'
         )

--- a/backend/local_app/kiva/statistics.py
+++ b/backend/local_app/kiva/statistics.py
@@ -1,6 +1,5 @@
 from django.db import connection, models
 
-from .models import Loan, Lender
 
 class Insights_sql(object):
     '''
@@ -15,14 +14,14 @@ class Insights_sql(object):
     2. Insights on Loans and Lenders : Most common sectors and activities for loan use 
     '''
     def get_loan_sector_info(self):
-        query = 'select 1 as id,sector_name, activity_name, trunc(avg(lender_term)) as average_lender_term_in_months, count(sector_name) as Count_of_loans, trunc(avg(loan_amount)) as Average_loan from loan group by sector_name, activity_name order by count(sector_name) desc'
+        query = 'select 1 as id,sector_name, activity_name, trunc(avg(lender_term)) as average_lender_term_in_months, count(sector_name) as count_of_loans, trunc(avg(loan_amount)) as average_loan from loan group by sector_name, activity_name order by count(sector_name) desc'
         return query
 
     '''
     3. Insights on Loans and Lenders: Average numbers of lenders per loan grouped by sector and activity
     '''
     def get_lenders_per_loan_by_activity(self):
-        query = 'select 1 as id,trunc(avg(a.count_of_lenders)) as average_lenders_per_loan, b.sector_name, b.activity_name from( SELECT loan_id, LENGTH(lenders) - LENGTH(REPLACE(lenders, \' \', \'\')) + 1 as Count_of_lenders FROM loan_lender order by count_of_lenders desc) a inner join loan b on a.loan_id = b.id group by b.sector_name, b.activity_name order by average_lenders_per_loan desc'
+        query = "select 1 as id,trunc(avg(a.count_of_lenders)) as average_lenders_per_loan, b.sector_name, b.activity_name from( SELECT loan_id, LENGTH(lenders) - LENGTH(REPLACE(lenders, ' \\', '\\')) + 1 as count_of_lenders FROM loan_lender order by count_of_lenders desc) a inner join loan b on a.loan_id = b.id group by b.sector_name, b.activity_name order by average_lenders_per_loan desc"
         return query
 
 

--- a/backend/local_app/kiva/views.py
+++ b/backend/local_app/kiva/views.py
@@ -2,8 +2,10 @@ from rest_framework import generics
 from django_filters import rest_framework as filters
 from django.core import serializers
 
-from .models import Lender, Loan
-from .serializers import LenderSerializer, LoanSerializer
+from .models import Lender, Loan, LoanStatsAvgLoanByCountry, LoanStatsCommonSectorsAndActivities,\
+    LoanStatsAvgLendersGroupedBySectorAndActivity
+from .serializers import LenderSerializer, LoanSerializer, LoanStatsAvgLoanByCountrySerializer,\
+    LoanStatsCommonSectorsAndActivitiesSerializer, LoanStatsAvgLendersGroupedBySectorAndActivitySerializer
 from .filters import LoanFilter, LenderFilter
 from .statistics import Insights_sql
 
@@ -62,26 +64,25 @@ class LoanDetail(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = LoanSerializer
 
 
-
 class Stats_1List(generics.ListAPIView):
     '''Average Loan Price per country sorted in descending order'''
     Stats = Insights_sql()
     query = Stats.get_average_loan_per_country()
-    queryset = Loan.objects.raw(query)
-    serializer_class = LoanSerializer
+    queryset = LoanStatsAvgLoanByCountry.objects.raw(query)
+    serializer_class = LoanStatsAvgLoanByCountrySerializer
 
 
 class Stats_2List(generics.ListAPIView):
     '''Most common sectors and activities for loan use'''
     Stats = Insights_sql()
     query = Stats.get_loan_sector_info()
-    queryset = Loan.objects.raw(query)
-    serializer_class = LoanSerializer
+    queryset = LoanStatsCommonSectorsAndActivities.objects.raw(query)
+    serializer_class = LoanStatsCommonSectorsAndActivitiesSerializer
 
 
 class Stats_3List(generics.ListAPIView):
     '''Average numbers of lenders per loan grouped by sector and activity'''
     Stats = Insights_sql()
     query = Stats.get_lenders_per_loan_by_activity()
-    queryset = Loan.objects.raw(query)
-    serializer_class = LoanSerializer
+    queryset = LoanStatsAvgLendersGroupedBySectorAndActivity.objects.raw(query)
+    serializer_class = LoanStatsAvgLendersGroupedBySectorAndActivitySerializer


### PR DESCRIPTION
### Context
- I noticed that the stats endpoints are returning the serialized `LoanModel`, which doesn't contain the stats from the raw queries

### What's Changing
- Adds models/serializers for stats endpoints
- Super minor modification to the `get_lenders_per_loan_by_activity` query
  - Noticed that this wasn't returning any results when executed via the endpoint, but was working fine in a sql client and found that the `\` character was causing problems

### Notes
- Each of the new models has `managed = False` so that they reference the `loan` table, but django will not attempt to apply any migrations for them - see https://docs.djangoproject.com/en/3.0/ref/models/options/#managed
- Tested this manually