### PR TITLE
Initial loan text search endpoint

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -36,6 +36,7 @@ DJANGO_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.postgres',
 ]
 
 THIRD_PARTY_APPS = [

--- a/backend/local_app/kiva/filters.py
+++ b/backend/local_app/kiva/filters.py
@@ -60,3 +60,8 @@ class LenderFilter(django_filters.FilterSet):
             'member_since',
             'loan_purchase_num'
         ]
+
+
+class LoanSearchFilter(django_filters.FilterSet):
+    # This is only added here so that the swagger docs will pickup the filter
+    search = django_filters.CharFilter()

--- a/backend/local_app/kiva/urls.py
+++ b/backend/local_app/kiva/urls.py
@@ -1,12 +1,13 @@
 from django.urls import path
 
-from .views import LenderList, LenderDetail, LoanList, LoanDetail, Stats_1List,Stats_2List,Stats_3List
+from .views import LenderList, LenderDetail, LoanList, LoanDetail, Stats_1List, Stats_2List, Stats_3List, LoanListSearch
 
 
 urlpatterns = [
     path('lender/', LenderList.as_view()),
     path('lender/<slug:pk>/', LenderDetail.as_view()),
     path('loan/', LoanList.as_view()),
+    path('loan/search/', LoanListSearch.as_view()),
     path('loan/<slug:pk>/', LoanDetail.as_view()),
     path('statistics/stats_1', Stats_1List.as_view()),
     path('statistics/stats_2', Stats_2List.as_view()),


### PR DESCRIPTION
### Context
- Adds an endpoint that we can use for full text search on loans

### Notes
- I used the `description_translated` field for the search because I figured that made the most sense since we'll only be supporting english (we _could_ try to support other languages in next iterations if we have time)
- I tested this manually and it seems to work really well. Feel free to clone the branch and try it out. I tried it with single keyword and multiple keywords and it consistently returns loans with variations of the keywords in their `description_translated` columns. For example I tried `gardening` and it also matched words like `garden`, `gardens`, `Garden`, etc.
- There's definitely still room for improvement/optimization in the future, but this will at least give us enough to start the frontend. For example it'd probably be useful to add a [gin index](https://docs.djangoproject.com/en/3.0/ref/contrib/postgres/indexes/#ginindex) to optimize the search